### PR TITLE
Allow to locally resolve the FQDN of a host via /etc/hosts to v6 lookback.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ v0.1.1
 - Update the task list so that correct hostname is set in ``/etc/hosts`` even
   when ``bootstrap_domain`` is not specified. [drybjed]
 
+- Added a IPv6 entry to ``/etc/hosts`` for the FQDN of the host pointing to the
+  IPv6 loopback address ::1. [ypid]
+
 v0.1.0
 ------
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -38,3 +38,15 @@ Bootstrap playbook does not have specific host restrictions, so it will be
 executed on all hosts (apart from ``localhost``) if not limited, which you
 should avoid.
 
+Ansible tags
+------------
+
+You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
+tasks are performed during Ansible run. This can be used after host is first
+configured to speed up playbook execution, when you are sure that most of the
+configuration has not been changed.
+
+Available role tags:
+
+``role::bootstrap:hostname``
+  Execute tasks related to configuring the hostname.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -170,6 +170,7 @@
 - name: Enforce new hostname
   hostname:
     name: '{{ bootstrap_hostname }}'
+  tags: [ 'role::bootstrap:hostname' ]
   when: (ansible_local|d() and ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled or
          (ansible_local.cap12s.enabled and 'cap_sys_admin' in ansible_local.cap12s.list)))
 
@@ -180,6 +181,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+  tags: [ 'role::bootstrap:hostname' ]
   when: (ansible_local|d() and ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled or
          (ansible_local.cap12s.enabled and 'cap_sys_admin' in ansible_local.cap12s.list)))
 
@@ -187,6 +189,13 @@
   lineinfile:
     state: 'present'
     dest: '/etc/hosts'
-    regexp: '{{ "^" + (bootstrap_ipv4 | default("127.0.1.1")) | replace(".","\.") }}'
-    line: '{{ (bootstrap_ipv4 | default("127.0.1.1")) + "\t" + (((bootstrap_hostname | d(ansible_hostname)) + "." + bootstrap_domain + "\t" + (bootstrap_hostname | d(ansible_hostname))) if bootstrap_domain|d() else (bootstrap_hostname | d(ansible_hostname))) }}'
+    insertafter: '{{ item.insertafter }}'
+    regexp: '{{ "^" + item.ip_address | replace(".","\.") }}'
+    line: '{{ item.ip_address + "\t" + (((bootstrap_hostname | d(ansible_hostname)) + "." + bootstrap_domain + "\t" + (bootstrap_hostname | d(ansible_hostname))) if bootstrap_domain|d() else (bootstrap_hostname | d(ansible_hostname))) }}'
+  tags: [ 'role::bootstrap:hostname' ]
+  with_items:
+    - ip_address: '{{ bootstrap_ipv4 | default("127.0.1.1") }}'
+      insertafter: '{{ "^127.0.0.1" | replace(".","\.") }}'
+    - ip_address: '{{ bootstrap_ipv6 | default("0::1") }}'
+      insertafter: '^::1'
 


### PR DESCRIPTION
* Related to: https://github.com/brianmario/mysql2/issues/686
* The slightly longer IPv6 address "0::1" is used to make lineinfile
  work because the file already contains mappings for "::1":

  ```
  ::1     localhost ip6-localhost ip6-loopback
  ```
* With this change `ping6 "$(hostname --fqdn)"` also works without DNS.
* Added tag `role::bootstrap:hostname`.