### PR TITLE
Fix IPv6 loopback resolution introduced in #8.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -189,7 +189,8 @@
   lineinfile:
     state: 'present'
     dest: '/etc/hosts'
-    insertafter: '{{ item.insertafter }}'
+    insertbefore: '{{ item.insertbefore | default(omit) }}'
+    insertafter: '{{ item.insertafter | default(omit) }}'
     regexp: '{{ "^" + item.ip_address | replace(".","\.") }}'
     line: '{{ item.ip_address + "\t" + (((bootstrap_hostname | d(ansible_hostname)) + "." + bootstrap_domain + "\t" + (bootstrap_hostname | d(ansible_hostname))) if bootstrap_domain|d() else (bootstrap_hostname | d(ansible_hostname))) }}'
   tags: [ 'role::bootstrap:hostname' ]
@@ -197,5 +198,5 @@
     - ip_address: '{{ bootstrap_ipv4 | default("127.0.1.1") }}'
       insertafter: '{{ "^127.0.0.1" | replace(".","\.") }}'
     - ip_address: '{{ bootstrap_ipv6 | default("0::1") }}'
-      insertafter: '^::1'
+      insertbefore: '^::1'
 


### PR DESCRIPTION
22fc14a58286c32a7e9388734a0a01b30c72ef00, #8.

* Since 22fc14a58286c32a7e9388734a0a01b30c72ef00 the `ansible_fqdn`
  resolves to "localhost". Related to: https://github.com/ansible/ansible/issues/9972
* This patch does not fix hosts already provisioned with the version
  22fc14a58286c32a7e9388734a0a01b30c72ef00 because it is expected that
  not many users already used it.
* Moving the v6 entry above localhost solves the issue.

Problem:

/etc/hosts

```
::1     localhost ip6-localhost ip6-loopback
0::1    host.testing   test
```

returns "localhost" for `python -c "import socket; print socket.getfqdn()"`

```
0::1    host.testing   test
::1     localhost ip6-localhost ip6-loopback
```

returns "host.testing" for `python -c "import socket; print socket.getfqdn()"`

@drybjed Maybe you can write a test for this?