### PR TITLE
Don`t enable local IPv6 loopback resolution by default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ v0.1.1
   when ``bootstrap_domain`` is not specified. [drybjed]
 
 - Added a IPv6 entry to ``/etc/hosts`` for the FQDN of the host pointing to the
-  IPv6 loopback address ::1. [ypid]
+  IPv6 loopback address "::1". Not enabled by default because it might break something.
+  Can be enabled by setting ``bootstrap_hostname_v6_loopback`` to True. [ypid]
 
 v0.1.0
 ------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,15 @@ bootstrap_domain: ''
 # Set custom DNS hostname on a given host.
 bootstrap_hostname: '{{ inventory_hostname_short | default(inventory_hostname) }}'
 
+# .. envvar:: bootstrap_hostname_v6_loopback
+#
+# Set custom DNS hostname on a given host also for IPv6.
+# This is only needed when you don’t have properly working DNS and still need
+# to resolve the hostname as IPv6 address.
+# Refer to https://github.com/debops/ansible-bootstrap/pull/9
+bootstrap_hostname_v6_loopback: False
+
+
 
 # --------------------
 #   APT and packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -194,9 +194,12 @@
     regexp: '{{ "^" + item.ip_address | replace(".","\.") }}'
     line: '{{ item.ip_address + "\t" + (((bootstrap_hostname | d(ansible_hostname)) + "." + bootstrap_domain + "\t" + (bootstrap_hostname | d(ansible_hostname))) if bootstrap_domain|d() else (bootstrap_hostname | d(ansible_hostname))) }}'
   tags: [ 'role::bootstrap:hostname' ]
+  when: item.type == 'inet6' and bootstrap_hostname_v6_loopback|d() or item.type == 'inet4'
   with_items:
     - ip_address: '{{ bootstrap_ipv4 | default("127.0.1.1") }}'
       insertafter: '{{ "^127.0.0.1" | replace(".","\.") }}'
+      type: 'inet4'
     - ip_address: '{{ bootstrap_ipv6 | default("0::1") }}'
       insertbefore: '^::1'
+      type: 'inet6'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -194,7 +194,7 @@
     regexp: '{{ "^" + item.ip_address | replace(".","\.") }}'
     line: '{{ item.ip_address + "\t" + (((bootstrap_hostname | d(ansible_hostname)) + "." + bootstrap_domain + "\t" + (bootstrap_hostname | d(ansible_hostname))) if bootstrap_domain|d() else (bootstrap_hostname | d(ansible_hostname))) }}'
   tags: [ 'role::bootstrap:hostname' ]
-  when: item.type == 'inet6' and bootstrap_hostname_v6_loopback|d() or item.type == 'inet4'
+  when: ((item.type == 'inet6' and bootstrap_hostname_v6_loopback|d()) or item.type == 'inet4')
   with_items:
     - ip_address: '{{ bootstrap_ipv4 | default("127.0.1.1") }}'
       insertafter: '{{ "^127.0.0.1" | replace(".","\.") }}'


### PR DESCRIPTION
Follow up for #9. See https://github.com/debops/ansible-bootstrap/pull/9#issuecomment-144059150

I am testing `bootstrap_hostname_v6_loopback: True` and check if it
breaks something.