### PR TITLE
Explicitly set `!requiretty` for the `bootstrap__sudo_group`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+v0.2.2
+------
+
+*Unreleased*
+
+- Explicitly set ``!requiretty`` for the :any:`bootstrap__sudo_group`
+  (:manpage:`sudoers(5)`). This ensures that ``sudo`` with ``rsync`` is allowed
+  for the :any:`bootstrap__sudo_group` even when ``requiretty`` has been
+  configured to be the default for users.
+
 v0.2.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ v0.2.2
 *Unreleased*
 
 - Explicitly set ``!requiretty`` for the :any:`bootstrap__sudo_group`
-  (:manpage:`sudoers(5)`). This ensures that ``sudo`` with ``rsync`` is allowed
+  (:manpage:`sudoers(5)`). This ensures that :command:`sudo` with :command:`rsync` is allowed
   for the :any:`bootstrap__sudo_group` even when ``requiretty`` has been
   configured to be the default for users.
 
@@ -64,17 +64,17 @@ v0.1.1
 
 *Released: 2015-11-07*
 
-- Update the task list so that correct hostname is set in ``/etc/hosts`` even
+- Update the task list so that correct hostname is set in :file:`/etc/hosts` even
   when ``bootstrap_domain`` is not specified. [drybjed]
 
-- Added a IPv6 entry to ``/etc/hosts`` for the FQDN of the host pointing to the
+- Added a IPv6 entry to :file:`/etc/hosts` for the FQDN of the host pointing to the
   IPv6 loopback address "::1". Not enabled by default because it might break something.
   Can be enabled by setting ``bootstrap_hostname_v6_loopback`` to True. [ypid]
 
 - Don't try and set SSH public key on ``root`` account when admin account
   management is disabled. [drybjed]
 
-- Remove the "\n" from ``/etc/hostname`` content line to prevent issues on
+- Remove the "\n" from :file:`/etc/hostname` content line to prevent issues on
   Ansible v2. [drybjed]
 
 - Replace the quotes in ``lineinfile`` module to prevent issues with ``\t``

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,13 +163,13 @@ bootstrap__admin_manage_existing: False
 
 # .. envvar:: bootstrap__sudo
 #
-# Configure passwordless ``sudo`` access for selected accounts.
+# Configure passwordless :command:`sudo` access for selected accounts.
 bootstrap__sudo: True
 
 
 # .. envvar:: bootstrap__sudo_group
 #
-# A group which grants passwordless ``sudo`` access.
+# A group which grants passwordless :command:`sudo` access.
 bootstrap__sudo_group: '{{ bootstrap__admin_groups[0] | default("") }}'
 
 # .. )))

--- a/docs/copyright.rst
+++ b/docs/copyright.rst
@@ -7,7 +7,7 @@ Copyright
     Copyright (C) 2015-2016 Robin Schneider <ypid@riseup.net>
     Copyright (C) 2015-2016 DebOps Project http://debops.org/
 
-    his program is free software; you can redistribute it and/or modify
+    This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as
     published by the Free Software Foundation.
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -8,7 +8,7 @@ Example inventory
 -----------------
 
 A host needs to be added to Ansible inventory to allow it to be bootstrapped.
-The default DebOps ``bootstrap.yml`` playbook expects the hosts to be in the
+The default DebOps :file:`bootstrap.yml` playbook expects the hosts to be in the
 ``[debops_all_hosts]`` Ansible group:
 
 .. code-block:: none
@@ -17,7 +17,7 @@ The default DebOps ``bootstrap.yml`` playbook expects the hosts to be in the
    hostname ansible_ssh_host=hostname.example.com
 
 You might want to set the default DNS domain used by your hosts. To do that,
-set the variable below in ``ansible/inventory/group_vars/all/bootstrap.yml`` or
+set the variable below in :file:`ansible/inventory/group_vars/all/bootstrap.yml` or
 in a similar place in inventory:
 
 .. code-block:: yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
+  tags: [ 'role::bootstrap:hostname' ]
 
 - name: Gather host facts
   action: setup
@@ -132,6 +133,8 @@
     validate: 'visudo -cf "%s"'
   tags: [ 'role::bootstrap:admin' ]
   with_items:
+    - regexp: '^Defaults: %{{ bootstrap__sudo_group }} !?requiretty'
+      line:    'Defaults: %{{ bootstrap__sudo_group }} !requiretty'
     - regexp: '^Defaults: %{{ bootstrap__sudo_group }} env_check\s'
       line:    'Defaults: %{{ bootstrap__sudo_group }} env_check += "SSH_CLIENT"'
     - regexp: '^%{{ bootstrap__sudo_group }}\s'


### PR DESCRIPTION
This ensures that `sudo` with `rsync` is allowed for the `bootstrap__sudo_group` even when `requiretty` has been configured to be the default for users.

I use [a role to configure sudo](https://github.com/ypid/ansible-sudo) on my systems and set `!requiretty` as default.

Form the manpage:

> If set, sudo will only run when the user is logged in to a real tty.  When this
> flag is set, sudo can only be run from a login session and not via other means
> such as cron(8) or cgi-bin scripts.  This flag is off by default.

So this patch is only required when the admin has changed the default from `!requiretty` to `requiretty` and wants to use `sudo` with `rsync` as a user in the `bootstrap__sudo_group`.

Related to: https://github.com/ansible/ansible/issues/4676#issuecomment-27605422