### PR TITLE
Allow to disable hostname and domain configuration.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@ v0.2.2
 - Explicitly set ``!requiretty`` for the :any:`bootstrap__sudo_group`
   (:manpage:`sudoers(5)`). This ensures that :command:`sudo` with :command:`rsync` is allowed
   for the :any:`bootstrap__sudo_group` even when ``requiretty`` has been
-  configured to be the default for users.
+  configured to be the default for users. [ypid]
+
+- Allow to disable hostname and domain configuration via
+  :any:`bootstrap__hostname_domain_config_enabled`. [ypid]
 
 v0.2.1
 ------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,12 @@
 #   Hostname and domain
 # -----------------------
 
+# .. envvar:: bootstrap__hostname_domain_config_enabled
+#
+# Should the hostname and domain be configured during bootstrap?
+bootstrap__hostname_domain_config_enabled: True
+
+
 # .. envvar:: bootstrap__domain
 #
 # Set custom DNS domain on a given host.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -165,7 +165,8 @@
   hostname:
     name: '{{ bootstrap__hostname }}'
   tags: [ 'role::bootstrap:hostname' ]
-  when: (bootstrap__hostname != ansible_hostname and
+  when: (bootstrap__hostname_domain_config_enabled|bool and
+         bootstrap__hostname != ansible_hostname and
          ansible_local|d() and ansible_local.cap12s|d() and
          (not ansible_local.cap12s.enabled|bool or
          'cap_sys_admin' in ansible_local.cap12s.list))
@@ -178,7 +179,8 @@
     group: 'root'
     mode: '0644'
   tags: [ 'role::bootstrap:hostname' ]
-  when: (bootstrap__hostname != ansible_hostname and
+  when: (bootstrap__hostname_domain_config_enabled|bool and
+         bootstrap__hostname != ansible_hostname and
          ansible_local|d() and ansible_local.cap12s|d() and
          (not ansible_local.cap12s.enabled|bool or
          'cap_sys_admin' in ansible_local.cap12s.list))
@@ -196,7 +198,7 @@
               if bootstrap__domain|d()
               else '') }}"
   tags: [ 'role::bootstrap:hostname' ]
-  when: ((item.type == 'inet6' and bootstrap__hostname_v6_loopback|d()) or item.type == 'inet4')
+  when: (bootstrap__hostname_domain_config_enabled|bool and ((item.type == 'inet6' and bootstrap__hostname_v6_loopback|d()) or item.type == 'inet4'))
   with_items:
     - ip_address: '{{ bootstrap__ipv4 | default("127.0.1.1") }}'
       insertafter: '{{ "^127.0.0.1" | replace(".", "\.") }}'


### PR DESCRIPTION
This is sometimes needed when you are configuring systems where these settings are managed by other means for example https://linuxmuster.net/.