### PR TITLE
ansible_ssh_user -> ansible_user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,12 +100,9 @@ bootstrap__admin_system: True
 # List of default user accounts created by the role. See
 # :ref:`bootstrap__ref_admin_users` for more details.
 bootstrap__admin_default_users:
-  - name: '{{ ansible_ssh_user
-              if (ansible_ssh_user | d() and
-                  ansible_ssh_user != "root")
-              else ansible_user
-                   if (ansible_user | d() and
-                   ansible_user != "root")
+  - name: '{{ ansible_user
+              if (ansible_user | d() and
+                  ansible_user != "root")
               else lookup("env", "USER") }}'
 
                                                                    # ]]]


### PR DESCRIPTION
Since Ansible 2.0.0 ansible_ssh_user is replaced by ansible_user