### PR TITLE
Ansible 1.7.0 -> Ansible 2.0.0

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -9,7 +9,7 @@ public keys for passwordless SSH access.
 Installation
 ~~~~~~~~~~~~
 
-This role requires at least Ansible ``v1.8.0``. To install it, run:
+This role requires at least Ansible ``v2.0.0``. To install it, run:
 
 .. code-block:: console
 


### PR DESCRIPTION
As ansible_ssh_user is replaced by ansible_user, minimum Ansible 2.0.0 is required